### PR TITLE
fix(logo): update margin-left on .dot-io

### DIFF
--- a/assets/css/_custom.scss
+++ b/assets/css/_custom.scss
@@ -10,5 +10,5 @@
 
 .dot-io {
   color: #123b34;
-  margin-left: 0.15em;
+  margin-left: 0.01em;
 }


### PR DESCRIPTION
## 📝 Description

Monia noticed the margin is too big. Thanks to her the logo looks better now.

## ✅ Checklist

- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have tested these changes locally.
- [x] I have updated documentation if needed.
