### PR TITLE
feat: update 'why this blog' section in the about page

### DIFF
--- a/content/about/index.en.md
+++ b/content/about/index.en.md
@@ -53,7 +53,7 @@ Besides keeping my code in repositories, I wanted a place to document **structur
 
 Everything in a clear and accessible way.
 
-This blog serves as my personal engineering notebook—a space I return to when designing systems, just like revisiting ADRs during architecture work.
+This blog serves as my personal engineering compendium — a space I return to when designing systems, just like revisiting ADRs during architecture work.
 
 It's my way of capturing patterns, learnings, and production-ready decisions that help me—and hopefully others—build **clean, scalable, and maintainable platforms**.
 

--- a/content/about/index.pl.md
+++ b/content/about/index.pl.md
@@ -53,7 +53,7 @@ Poza przechowywaniem kodu w repozytoriach chciałem mieć miejsce do dokumentowa
 
 Wszystko w sposób przejrzysty i dostępny.
 
-Ten blog jest moim osobistym notesem inżynierskim – przestrzenią, do której wracam podczas projektowania systemów, podobnie jak wraca się do ADR-ów przy podejmowaniu decyzji architektonicznych.
+Ten blog jest moim osobistym inżynierskim kompendium – przestrzenią, do której wracam podczas projektowania systemów, podobnie jak wraca się do ADR-ów przy podejmowaniu decyzji architektonicznych.
 
 To mój sposób na uchwycenie wzorców, lekcji i decyzji produkcyjnych, które pomagają mi – i być może innym – budować **czyste, skalowalne i łatwe w utrzymaniu platformy**.
 


### PR DESCRIPTION
## 📝 Description

The word "notebook" repeats in the welcome post and the about page. It can be changed in the about page.

## ✅ Checklist

- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have tested these changes locally.
- [x] I have updated documentation if needed.
