### PR TITLE
fix(post): adjust code formatting in gradle init for Spring Boot

### DIFF
--- a/content/posts/2025-08-28-gradle-init-for-spring-boot/index.en.md
+++ b/content/posts/2025-08-28-gradle-init-for-spring-boot/index.en.md
@@ -24,7 +24,7 @@ The plugin is open-source and available on the [Gradle - Plugins](https://plugin
 
 Create the `build.gradle` file and add the following:
 
-```
+```groovy
 plugins {
     id 'io.oczadly.springinitializr' version '1.0.0'
 }
@@ -32,7 +32,7 @@ plugins {
 
 Create the settings.gradle file and add this configuration:
 
-```
+```groovy
 rootProject.name = 'examples-simple-groovy'
 ```
 
@@ -89,7 +89,7 @@ gradle initSpringBootProject
 
 You will get:
 
-```
+```text
 > Task :initSpringBootProject
 Downloading Spring Boot starter project...
 Project downloaded to: /opt/my-projects/build/generated-project/starter.zip
@@ -243,7 +243,7 @@ gradle initSpringBootProject -Planguage=clojure
 
 Will result in the message:
 
-```
+```text
 > Task :initSpringBootProject FAILED
 
 FAILURE: Build failed with an exception.
@@ -432,7 +432,7 @@ BUILD SUCCESSFUL in 3s
 
 The tests did not pass, and I was getting the following message in the logs:
 
-```
+```text
 Condition not satisfied:
 
 FilesTestUtils.projectFilesExist unzipDir, 'build.gradle', 'src/main/java/com/example/demo/DemoApplication.java'

--- a/content/posts/2025-08-28-gradle-init-for-spring-boot/index.pl.md
+++ b/content/posts/2025-08-28-gradle-init-for-spring-boot/index.pl.md
@@ -25,7 +25,7 @@ Plugin jest open source i dostępny w [Gradle - Plugins](https://plugins.gradle.
 
 Stwórz plik `build.gradle` oraz dodaj poniższe:
 
-```
+```groovy
 plugins {
     id 'io.oczadly.springinitializr' version '1.0.0'
 }
@@ -33,7 +33,7 @@ plugins {
 
 Następnie stwórz plik `settings.gradle` i dodaj konfigurację:
 
-```
+```groovy
 rootProject.name = 'examples-simple-groovy'
 ```
 
@@ -82,7 +82,7 @@ Po zainstalowaniu [gradle-springinitializr-plugin](https://plugins.gradle.org/pl
 
 Plugin udostępnia pojedynczy task `initSpringBootProject`, który pobiera projekt z [Spring Initializr](https://start.spring.io/) i następnie rozpakowuje go. Zamiast klikać w interfejs webowy, wystarczy uruchomić:
 
-```bash
+```shell
 gradle initSpringBootProject
 ```
 
@@ -101,7 +101,7 @@ Domyślnie projekt zostanie pobrany i rozpakowany do `build/generated-project/de
 
 Plugin pozwala także ustawić dowolny parametr dostępny w [Spring Initializr](https://start.spring.io/):
 
-```bash
+```shell
 gradle initSpringBootProject \
     -PprojectType="gradle-project-kotlin" \
     -Planguage="kotlin" \


### PR DESCRIPTION
## 📝 Description

Adjusts code formatting in the "gradle init dla Spring Boot" article.

## ✅ Checklist

- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have tested these changes locally.
- [x] I have updated documentation if needed.
