### PR TITLE
feat(main-page): add Series section

### DIFF
--- a/content/posts/2025-09-26-azure-iac-built-for-your-needs/index.en.md
+++ b/content/posts/2025-09-26-azure-iac-built-for-your-needs/index.en.md
@@ -1,6 +1,7 @@
 ---
 title: "Azure IaC built for your needs"
 subtitle: "Architectural patterns. A foundation to scale — powered by OpenTofu and AVM."
+series: ["Infrastructure at scale with Azure and OpenTofu"]
 date: 2025-09-26
 description: "Architectural patterns. A foundation to scale — powered by OpenTofu and AVM."
 draft: false

--- a/content/posts/2025-09-26-azure-iac-built-for-your-needs/index.pl.md
+++ b/content/posts/2025-09-26-azure-iac-built-for-your-needs/index.pl.md
@@ -1,6 +1,7 @@
 ---
 title: "Azure IaC zbudowana dla Twoich potrzeb"
 subtitle: "Wzorce architektoniczne i gotowe narzędzia do dalszej rozbudowy — oparte na OpenTofu i AVM."
+series: ["Infrastructure at scale with Azure and OpenTofu"]
 date: 2025-09-26
 description: "Wzorce architektoniczne i gotowe narzędzia do dalszej rozbudowy — oparte na OpenTofu i AVM."
 draft: false

--- a/content/series/infrastructure-at-scale-with-azure-and-opentofu/_index.en.md
+++ b/content/series/infrastructure-at-scale-with-azure-and-opentofu/_index.en.md
@@ -1,0 +1,5 @@
+---
+title: "Infrastructure at scale with Azure and OpenTofu"
+description: "A comprehensive series on designing, building, and maintaining production-ready infrastructure as code on Microsoft Azure using OpenTofu. Learn architectural patterns, module best practices, and CI/CD workflows that scale."
+draft: false
+---

--- a/content/series/infrastructure-at-scale-with-azure-and-opentofu/_index.pl.md
+++ b/content/series/infrastructure-at-scale-with-azure-and-opentofu/_index.pl.md
@@ -1,0 +1,5 @@
+---
+title: "Infrastruktura w skali z Azure i OpenTofu"
+description: "Kompletna seria o projektowaniu, budowaniu i utrzymaniu produkcyjnej infrastruktury jako kod na Microsoft Azure z użyciem OpenTofu. Naucz się wzorców architektonicznych, najlepszych praktyk modulów i przepływów CI/CD, które skalują się."
+draft: false
+---

--- a/hugo.toml
+++ b/hugo.toml
@@ -12,11 +12,16 @@ title = "oczadly.io - production-ready tooling. Clean solutions."
     languageName = "English"
     [[languages.en.menu.main]]
       weight = 1
+      identifier = "series"
+      name = "Series"
+      url = "/series/"
+    [[languages.en.menu.main]]
+      weight = 2
       identifier = "posts"
       name = "Posts"
       url = "/posts/"
     [[languages.en.menu.main]]
-      weight = 2
+      weight = 3
       identifier = "about"
       name = "About"
       url = "/about/"
@@ -27,11 +32,16 @@ title = "oczadly.io - production-ready tooling. Clean solutions."
     languageName = "Polski"
     [[languages.pl.menu.main]]
       weight = 1
+      identifier = "series"
+      name = "Serie"
+      url = "/series/"
+    [[languages.pl.menu.main]]
+      weight = 2
       identifier = "posts"
       name = "Wpisy"
       url = "/posts/"
     [[languages.pl.menu.main]]
-      weight = 2
+      weight = 3
       identifier = "about"
       name = "O blogu"
       url = "/about/"
@@ -40,6 +50,11 @@ title = "oczadly.io - production-ready tooling. Clean solutions."
   [markup.highlight]
     lineNos = true
     noClasses = false
+
+[taxonomies]
+  category = "categories"
+  tag = "tags"
+  series = "series"
 
 [menu]
   [[menu.main]]

--- a/layouts/_default/term.html
+++ b/layouts/_default/term.html
@@ -1,0 +1,43 @@
+{{- define "title" }}
+    {{- .Title }} - {{ .Site.Title -}}
+{{- end -}}
+
+{{- define "content" -}}
+    <div class="page archive">
+        {{- /* Title */ -}}
+        <h2 class="single-title animate__animated animate__pulse animate__faster">
+            {{- .Title -}}
+        </h2>
+
+        {{- /* Description */ -}}
+        {{ with .Description }}
+        <div class="post-meta">
+            <span class="post-description">{{ . }}</span>
+        </div>
+        {{ end }}
+
+        {{- /* Pages */ -}}
+        {{- if .Pages -}}
+            {{- $pages := .Pages.GroupByDate "2006" -}}
+            {{- with .Site.Params.section.paginate | default .Site.Params.paginate -}}
+                {{- $pages = $.Paginate $pages . -}}
+            {{- else -}}
+                {{- $pages = $.Paginate $pages -}}
+            {{- end -}}
+            {{- range $pages.PageGroups -}}
+                <h3 class="group-title">{{ .Key }}</h3>
+                {{- range .Pages -}}
+                    <article class="archive-item">
+                        <a href="{{ .RelPermalink }}" class="archive-item-link">
+                            {{- .Title | emojify -}}
+                        </a>
+                        <span class="archive-item-date">
+                            {{- $.Site.Params.section.dateFormat | default "01-02" | .Date.Format -}}
+                        </span>
+                    </article>
+                {{- end -}}
+            {{- end -}}
+            {{- partial "paginator.html" . -}}
+        {{- end -}}
+    </div>
+{{- end -}}

--- a/layouts/taxonomy/terms.html
+++ b/layouts/taxonomy/terms.html
@@ -1,0 +1,57 @@
+{{- define "title" -}}
+    {{- .Params.Title | default (T .Data.Plural) | default .Data.Plural | dict "Some" | T "allSome" }} - {{ .Site.Title -}}
+{{- end -}}
+
+{{- define "content" -}}
+    {{- $taxonomies := .Data.Plural -}}
+    {{- $terms := .Data.Terms.ByCount -}}
+    {{- $type := .Type -}}
+
+    <div class="page archive">
+        {{- /* Title */ -}}
+        <h2 class="single-title animate__animated animate__pulse animate__faster">
+            {{- .Params.Title | default (T $taxonomies) | default $taxonomies | dict "Some" | T "allSome" -}}
+        </h2>
+
+        {{- /* Categories & Series Page */ -}}
+        {{- if or (eq $taxonomies "categories") (eq $taxonomies "series") -}}
+            <div class="categories-card">
+                {{- range $terms -}}
+                    {{- $term := .Term -}}
+                    {{- $pages := .Pages -}}
+                    {{- with $.Site.GetPage "taxonomy" (printf "%v/%v" $type $term) -}}
+                    <div class="card-item">
+                        <div class="card-item-wrapper">
+                            <h3 class="card-item-title">
+                                <a href="{{ .RelPermalink }}">
+                                    <i class="far fa-folder fa-fw" aria-hidden="true"></i>&nbsp;{{ .Page.Title }}
+                                </a>
+                            </h3>
+                            {{- range first 5 $pages -}}
+                                <article class="archive-item">
+                                    <a href="{{ .RelPermalink }}" class="archive-item-link">
+                                        {{- .Title | emojify -}}
+                                    </a>
+                                </article>
+                            {{- end -}}
+                            {{- if gt (len $pages) 5 -}}
+                                <span class="more-post">
+                                    <a href="{{ .RelPermalink }}" class="more-single-link">{{ T "more" }} >></a>
+                                </span>
+                            {{- end -}}
+                        </div>
+                    </div>
+                    {{- end -}}
+                {{- end -}}
+            </div>
+
+        {{- /* Tag Cloud Page */ -}}
+        {{- else if eq $taxonomies "tags" -}}
+            <div class="tag-cloud-tags">
+                {{- range $.Site.Taxonomies.tags.ByCount -}}
+                    <a href="{{ .Page.RelPermalink }}">{{ .Page.Title }} <sup>{{ .Count }}</sup></a>
+                {{- end -}}
+            </div>
+        {{- end -}}
+    </div>
+{{- end -}}


### PR DESCRIPTION
## 📝 Description

This PR adds the following:
:rocket: [Series](https://oczadly.io/series/) section to the main page.
:rocket: First series [Infrastructure at scale with Azure and OpenTofu](https://oczadly.io/series/infrastructure-at-scale-with-azure-and-opentofu/).
:wrench: Required Hugo configuration to display the content correctly.

## ✅ Checklist

- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have tested these changes locally.
- [x] I have updated documentation if needed.
