### PR TITLE
style(refactoring-hcl-organization-wide-with-openrewrite): add separators

### DIFF
--- a/content/posts/2026-04-23-refactoring-hcl-organization-wide-with-openrewrite/index.en.md
+++ b/content/posts/2026-04-23-refactoring-hcl-organization-wide-with-openrewrite/index.en.md
@@ -17,6 +17,8 @@ In theory, these are _"simple"_ updates: bumping a version, removing an input, a
 
 In this article, I show how to approach infrastructure-as-code migrations in a deterministic, repeatable, and safe way, using lossless, structure-aware refactoring rather than text-based transformations. Using real-world [Azure Verified Modules](https://azure.github.io/Azure-Verified-Modules/) (AVM) module migrations as examples, I demonstrate how to produce changes that land as clean, reviewable pull requests instead of manual edits scattered across a repository.
 
+---
+
 ## Why OpenRewrite
 
 The key difference between structural refactoring and traditional text-based tooling is that changes are applied to the **semantic structure of the configuration**, not to its raw textual representation. [OpenRewrite](https://docs.openrewrite.org/) is built around _lossless semantic trees (LST)_. It's a representation that preserves all information from the original source files, including formatting, comments, and ordering, while still allowing safe, semantic transformations.
@@ -32,6 +34,8 @@ It's also worth noting that this approach is not limited to HCL or [OpenTofu](ht
 This means the same workflow: explicit recipes, deterministic execution, and pull requests as output can be applied to [Kubernetes](https://kubernetes.io/) manifest migrations, API changes, or GitOps refactoring. This, however, deserves a separate case study.
 
 {{< /admonition >}}
+
+---
 
 ## Case study
 
@@ -248,9 +252,9 @@ As shown above, changes span three files:
 
 What you do for one Private DNS Zone, you can replicate for ten. The same recipe and parameters always yield the same result. Without scripts, without manual fixes, without the risk of missing something.
 
----
-
 At this point, the migration is ready for `rewriteRun` execution and can be approved in the standard code review process as a normal pull request, without additional scripts, exceptions, or manual fixes.
+
+---
 
 ## Architecture of the solution
 
@@ -283,6 +287,8 @@ In practice, YAML recipes form a __policy layer__, enabling repeatable, determin
 To make these migrations repeatable, I run them through a [Gradle](https://gradle.org/) based workflow. [Gradle](https://gradle.org/) acts as the execution engine: it resolves [OpenRewrite](https://docs.openrewrite.org/) recipes, applies them consistently across repositories, and produces deterministic results that can be validated locally or in CI.
 
 In environments where [Develocity](https://gradle.com/develocity/) is already in use, the same workflow can publish [Build Scans](https://docs.gradle.org/9.0.0/userguide/build_scans.html). This makes it easier to observe execution characteristics and compare results across repositories without requiring any changes to the underlying workflow.
+
+---
 
 ## Safety guarantees
 
@@ -320,6 +326,8 @@ Additionally, Java recipes are published to [Maven Central](https://central.sona
 
 Running migrations in `rewriteDryRun` mode, similarly to `tofu plan` / `terraform plan`, allows inspecting the full scope of planned changes without modifying code. This creates space to assess impact, catch unexpected effects, and make informed decisions before applying changes.
 
+---
+
 ## Why this scales across organizations
 
 This approach scales not because of the tools involved, but because it addresses the problem at the right level of abstraction. Migrations are treated not as one-off tasks performed manually in individual repositories, but as an explicitly described process that can be reused accross contexts.
@@ -332,6 +340,8 @@ Responsibilities are clearly separated:
 
 As a result, the same migration can be applied across many repositories, executed by different teams, and integrated into existing CI/CD and code review workflows without requiring a centralized platform.
 
+---
+
 ## When this approach does not make sense
 
 This approach is not a universal solution. For small IaC projects consisting of a single module with no planned evolution, the overhead of introducing an additional process may outweigh its benefits.
@@ -339,6 +349,8 @@ This approach is not a universal solution. For small IaC projects consisting of 
 Similarly, for one-off, trivial changes, such as bumping a version in a single place, tools like [Renovate](https://docs.renovatebot.com/) or even manual edits may be simpler and more appropriate.
 
 The approach also assumes a certain level of organizational maturity: working with pull requests, code review, and treating migrations as part of long-term maintenance rather than incidental fixes.
+
+---
 
 ## Summary
 

--- a/content/posts/2026-04-23-refactoring-hcl-organization-wide-with-openrewrite/index.pl.md
+++ b/content/posts/2026-04-23-refactoring-hcl-organization-wide-with-openrewrite/index.pl.md
@@ -17,6 +17,8 @@ W teorii są to _"proste"_ zmiany: zmiana wersji, usunięcie parametru, dodanie 
 
 W tym artykule pokazuję, jak podejść do migracji infrastruktury jako kod w sposób deterministyczny, powtarzalny i bezpieczny, wykorzystując refaktoryzację opartą o strukturalną analizę konfiguracji, zachowującą jej semantykę i formatowanie. Na przykładzie rzeczywistych migracji modułów [Azure Verified Modules](https://azure.github.io/Azure-Verified-Modules/) (AVM) pokazuję, jak przygotować zmiany, które trafiają do pull requesta jako czytelny diff zamiast ręcznej pracy rozproszonej po repozytorium.
 
+---
+
 ## Dlaczego OpenRewrite
 
 Kluczową różnicą pomiędzy podejściem opartym o refaktoryzację strukturalną a klasycznymi narzędziami tekstowymi jest to, że operujemy na **semantycznej reprezentacji konfiguracji**, a nie na jej surowej postaci tekstowej. [OpenRewrite](https://docs.openrewrite.org/) wykorzystuje tzw. _lossless semantic trees (LST)_, czyli strukturę, która zachowuje pełną informację o oryginalnym pliku, w tym formatowanie, komentarze i kolejność elementów, jednocześnie umożliwiając bezpieczne modyfikacje semantyczne.
@@ -32,6 +34,8 @@ Warto też zauważyć, że to podejście nie jest ograniczone do HCL ani [OpenTo
 Oznacza to, że ten sam model pracy, czyli jawne recipes, deterministyczne wykonanie i pull request jako wynik, może być zastosowany również do migracji manifestów Kubernetesowych, zmian API czy refaktoryzacji konfiguracji GitOps. To temat na osobne case study.
 
 {{< /admonition >}}
+
+---
 
 ## Case study
 
@@ -247,9 +251,9 @@ Jak widać powyżej, zmiany dotyczą trzech plików:
 
 To, co robisz dla jednej Private DNS Zone, możesz odtworzyć dla dziesięciu. Ta sama recipe i parametry zawsze dają ten sam efekt. Bez skryptów, bez ręcznych poprawek, bez ryzyka, że coś przeoczyłeś.
 
----
-
 Na tym etapie migracja jest gotowa do uruchomienia przez taska `rewriteRun` i zatwierdzenia w standardowym procesie code review jako zwykły pull request, bez dodatkowych skryptów, wyjątków czy ręcznych poprawek.
+
+---
 
 ## Architektura rozwiązania
 
@@ -282,6 +286,8 @@ W praktyce YAML recipes pełnią rolę warstwy decyzyjnej (_"policy layer"_). Po
 Aby uczynić te migracje powtarzalnymi, wykorzystuję [Gradle](https://gradle.org/) jako silnik wykonawczy. Odpowiada on za uruchamianie recipes [OpenRewrite](https://docs.openrewrite.org/), zapewnia spójność wykonania i umożliwia łatwe odtworzenie tego samego procesu lokalnie oraz w CI.
 
 W organizacjach, które już korzystają z [Develocity](https://gradle.com/develocity/), ten sam workflow może publikować [Build Scan'y](https://docs.gradle.org/9.0.0/userguide/build_scans.html), co daje dodatkowe observability przebiegu migracji oraz możliwość porównywania wyników pomiędzy projektami, bez zmiany samego modelu wykonania.
+
+---
 
 ## Gwarancje bezpieczeństwa
 
@@ -331,6 +337,8 @@ Daje to przestrzeń na:
 
 Bezpieczeństwo przedstawionego podejścia nie opiera się na ręcznej kontroli ani ostrożności, lecz na **właściwościach systemu**: deterministyczności, idempotentności oraz jawności zmian. Dzięki temu migracje infrastruktury jako kod przestają być jednorazowym, ryzykownym wydarzeniem, a stają się powtarzalnym i kontrolowanym procesem.
 
+---
+
 ## Dlaczego to skaluje się w organizacji
 
 Opisane podejście skaluje się w organizacji nie dlatego, że wykorzystuje konkretne narzędzia, ale dlatego, że **adresuje problem na właściwym poziomie abstrakcji**. Migracje nie są tu traktowane jako jednorazowe zadania wykonywane ręcznie w poszczególnych repozytoriach, lecz jako **jawnie opisany proces**, który można wielokrotnie zastosować w różnych kontekstach.
@@ -345,6 +353,8 @@ Dzięki temu ta sama migracja może być zastosowana w wielu repozytoriach, uruc
 
 Co istotne, to podejście nie wymaga centralnego systemu, ani dedykowanej platformy. Wystarczają repozytoria Git oraz standardowy workflow pull requestów. To wszystko sprawia, że rozwiązanie dobrze wpisuje się w realia organizacji o różnym poziomie dojrzałości.
 
+---
+
 ## Kiedy to podejście nie ma sensu
 
 Opisane podejście nie będzie dobrym rozwiązaniem w sytuacji, gdy projekt infrastruktury jako kod jest niewielki, obejmuje pojedynczy moduł i nie planuje się jego dalszego rozwoju ani aktualizacji. W tym przypadku koszt wprowadzenia dodatkowego procesu może przewyższyć potencjalne korzyści.
@@ -352,6 +362,8 @@ Opisane podejście nie będzie dobrym rozwiązaniem w sytuacji, gdy projekt infr
 Podobnie, w sytuacjach wymagających jednorazowej, standardowej zmiany (np. tylko podbicia wersji w jednym miejscu), modyfikacja przez [Renovate](https://docs.renovatebot.com/) / inną automatyzację lub nawet ręczna może być prostszym i bardziej adekwatnym rozwiązaniem.
 
 Warto też podkreślić, że podejście to zakłada pewien poziom dojrzałości organizacyjnej: pracę z pull requestami, code review oraz gotowość do traktowania migracji jako elementu długofalowego utrzymania, a nie incydentalnej poprawki.
+
+---
 
 ## Podsumowanie
 


### PR DESCRIPTION
## 📝 Description

Add paragraph separators to [Refactoring HCL organization-wide with OpenRewrite](https://oczadly.io/posts/2026-04-23-refactoring-hcl-organization-wide-with-openrewrite/).

## ✅ Checklist

- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have tested these changes locally.
- [x] I have updated documentation if needed.
