### PR TITLE
feat(about): add Terraform Weekly 278 to referenced by

### DIFF
--- a/content/about/index.en.md
+++ b/content/about/index.en.md
@@ -73,6 +73,7 @@ It's my way of capturing patterns, learnings, and production-ready decisions tha
 
 Selected articles and projects from this blog have been referenced by engineering communities and official documentation:
 
+* [Terraform Weekly #278](https://www.weekly.tf/p/issue-278-scale-azure-iac-on-opentofu-and-avm-clone-full-ecs-stacks-govern-terraform-on-github): featured [Azure IaC built for your needs](../posts/2025-09-26-azure-iac-built-for-your-needs) as a practical article on organizing Azure IaC with OpenTofu, Azure Verified Modules, and isolated state files.
 * [OpenRewrite Documentation](https://docs.openrewrite.org/running-recipes/running-rewrite-on-an-infrastructure-as-code-project#option-2-host-gradle-project): referenced [avm-openrewrite-migrations](https://github.com/infra-at-scale/avm-openrewrite-migrations) and the accompanying case study as a complete working setup for running OpenRewrite on Infrastructure-as-Code projects.
 * [Gradle Newsletter, May 2026](https://newsletter.gradle.org/2026/05#refactoring-hcl-w-openrewrite): featured [Refactoring HCL with OpenRewrite](../posts/2026-04-23-refactoring-hcl-organization-wide-with-openrewrite) as a community article on structured Terraform/OpenTofu migrations.
 * [Gradle Newsletter, September 2025](https://newsletter.gradle.org/2025/09#level-up-your-builds-with-plugins-from-the-gradle-team): featured the [Spring Initializr Gradle Plugin](https://plugins.gradle.org/plugin/io.oczadly.springinitializr) as a reference implementation for production-ready Gradle plugin development.

--- a/content/about/index.pl.md
+++ b/content/about/index.pl.md
@@ -72,6 +72,7 @@ To mój sposób na uchwycenie wzorców, lekcji i decyzji produkcyjnych, które p
 
 Wybrane artykuły i projekty z tego bloga zostały przywołane przez społeczności inżynierskie i oficjalną dokumentację:
 
+* [Terraform Weekly #278](https://www.weekly.tf/p/issue-278-scale-azure-iac-on-opentofu-and-avm-clone-full-ecs-stacks-govern-terraform-on-github): wyróżnia [Azure IaC built for your needs](../posts/2025-09-26-azure-iac-built-for-your-needs) jako praktyczny artykuł o organizowaniu Azure IaC z użyciem OpenTofu, Azure Verified Modules oraz izolowanych plików stanu.
 * [Dokumentacja OpenRewrite](https://docs.openrewrite.org/running-recipes/running-rewrite-on-an-infrastructure-as-code-project#option-2-host-gradle-project): wskazuje [avm-openrewrite-migrations](https://github.com/infra-at-scale/avm-openrewrite-migrations) oraz towarzyszące case study jako kompletną, działającą konfigurację do uruchamiania OpenRewrite na projektach Infrastructure-as-Code.
 * [Gradle Newsletter, maj 2026](https://newsletter.gradle.org/2026/05#refactoring-hcl-w-openrewrite): wyróżnia [Refaktoryzację HCL z OpenRewrite](../posts/2026-04-23-refactoring-hcl-organization-wide-with-openrewrite) jako społecznościowy artykuł o ustrukturyzowanych migracjach Terraform/OpenTofu.
 * [Gradle Newsletter, wrzesień 2025](https://newsletter.gradle.org/2025/09#level-up-your-builds-with-plugins-from-the-gradle-team): prezentuje [Spring Initializr Gradle Plugin](https://plugins.gradle.org/plugin/io.oczadly.springinitializr) jako referencyjną implementację produkcyjnego rozwoju pluginów Gradle.


### PR DESCRIPTION
## 📝 Description

[Terraform Weekly 278](https://www.weekly.tf/p/issue-278-scale-azure-iac-on-opentofu-and-avm-clone-full-ecs-stacks-govern-terraform-on-github) references "Azure IaC built for your needs" :rocket: Adding that to the "Referenced by" section.

## ✅ Checklist

- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have tested these changes locally.
- [x] I have updated documentation if needed.
