### PR TITLE
feat(about): update image portrait position

### DIFF
--- a/assets/css/_custom.scss
+++ b/assets/css/_custom.scss
@@ -12,3 +12,36 @@
   color: #123b34;
   margin-left: 0.01em;
 }
+
+.single .content .about-portrait {
+  float: left;
+  width: 30.4%;
+  max-width: 191px;
+  margin: 0 1.5rem 1rem 0;
+  border-radius: .5rem;
+}
+
+// Keep the About-page disclaimer below the floated portrait.
+.single .content > h3#work + p + .admonition,
+.single .content > h3#praca + p + .admonition {
+  clear: left;
+}
+
+// Align the English About-page tagline's full quote block beside the portrait.
+.single .content > h2#paweł-oczadły + blockquote {
+  margin-left: 215px;
+}
+
+@media (max-width: 680px) {
+  .single .content .about-portrait {
+    float: none;
+    display: block;
+    width: 100%;
+    max-width: 191px;
+    margin: 0 auto 1rem;
+  }
+
+  .single .content > h2#paweł-oczadły + blockquote {
+    margin-left: 0;
+  }
+}

--- a/content/about/index.en.md
+++ b/content/about/index.en.md
@@ -5,7 +5,7 @@ draft: false
 type: "page"
 ---
 
-![about](/featured-image.jpeg)
+![about portrait](/featured-image.jpeg)
 
 ## Paweł Oczadły
 
@@ -22,8 +22,6 @@ Currently working at **[Gradle Technologies](https://gradle.com/)** on building 
 {{< admonition note "Note" >}}
 *Posts about [Gradle](https://gradle.org/), [DPE University](https://dpeuniversity.gradle.com/app), [Build Scans](https://docs.gradle.org/8.14.3/userguide/build_scans.html), or [Develocity](https://gradle.com/develocity/) reflect my **personal experiences and perspectives**. They are not official product endorsements or company statements but insights I've gained while working with these tools in real engineering workflows.*
 {{< /admonition >}}
-
----
 
 ### After work
 

--- a/content/about/index.pl.md
+++ b/content/about/index.pl.md
@@ -5,7 +5,7 @@ draft: false
 type: "page"
 ---
 
-![about](/featured-image.jpeg)
+![about portrait](/featured-image.jpeg)
 
 ## Paweł Oczadły
 
@@ -22,8 +22,6 @@ Obecnie pracuję w **[Gradle Technologies](https://gradle.com/)**, budując syst
 {{< admonition note "Uwaga" >}}
 *Wpisy dotyczące [Gradle](https://gradle.org/), [DPE University](https://dpeuniversity.gradle.com/app), [Build Scans](https://docs.gradle.org/8.14.3/userguide/build_scans.html) czy [Develocity](https://gradle.com/develocity/) odzwierciedlają moje **osobiste doświadczenia i perspektywy**. Nie są oficjalnymi rekomendacjami produktów ani stanowiskiem firmy, lecz insightami, które zdobyłem, pracując z tymi narzędziami w realnych workflow inżynierskich.*
 {{< /admonition >}}
-
----
 
 ### Po pracy
 

--- a/layouts/_default/_markup/render-image.html
+++ b/layouts/_default/_markup/render-image.html
@@ -1,0 +1,14 @@
+{{- $class := "" -}}
+{{- if and (or (eq .Page.File.Path "about/index.en.md") (eq .Page.File.Path "about/index.pl.md")) (eq .Destination "/featured-image.jpeg") -}}
+    {{- $class = "about-portrait" -}}
+{{- end -}}
+{{- if .Title -}}
+    <figure>
+        {{- dict "Src" .Destination "Title" .Text "Caption" .Title "Linked" true "Class" $class "Resources" .Page.Resources | partial "plugin/img.html" -}}
+        <figcaption class="image-caption">
+            {{- .Title | safeHTML -}}
+        </figcaption>
+    </figure>
+{{- else -}}
+    {{- dict "Src" .Destination "Title" .Text "Class" $class "Resources" .Page.Resources | partial "plugin/img.html" -}}
+{{- end -}}


### PR DESCRIPTION
## 📝 Description

The portrait image is on the left side of the page now, text on the right side.

## ✅ Checklist

- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have tested these changes locally.
- [x] I have updated documentation if needed.
