### PR TITLE
chore: add Docker setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git
+.hugo_build.lock
+public
+resources
+tmp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM alpine:3.24 AS hugo
+
+ARG HUGO_VERSION=0.147.0
+ARG TARGETARCH
+
+RUN set -eux; \
+    case "${TARGETARCH}" in \
+        amd64|arm64) ;; \
+        *) echo "Unsupported architecture: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac; \
+    apk add --no-cache ca-certificates curl; \
+    curl --fail --location \
+        --output /tmp/hugo.tar.gz \
+        "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-${TARGETARCH}.tar.gz"; \
+    tar --extract --gzip \
+        --file /tmp/hugo.tar.gz \
+        --directory /usr/local/bin \
+        hugo
+
+FROM gcr.io/distroless/cc-debian13:nonroot
+
+COPY --from=hugo /usr/local/bin/hugo /usr/local/bin/hugo
+
+WORKDIR /src
+
+EXPOSE 1313
+
+ENTRYPOINT ["/usr/local/bin/hugo"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,20 @@
+services:
+  hugo:
+    build:
+      context: .
+      args:
+        HUGO_VERSION: 0.147.0
+    user: "${UID:-1000}:${GID:-1000}"
+    command:
+      - server
+      - --bind=0.0.0.0
+      - --baseURL=http://localhost:1313/
+      - --buildDrafts
+      - --buildFuture
+      - --disableFastRender
+      - --renderToMemory
+    ports:
+      - "1313:1313"
+    volumes:
+      - .:/src
+    init: true


### PR DESCRIPTION
## 📝 Description

Adds Docker setup for running the blog locally without the need to install Hugo and other dependencies.

## ✅ Checklist

- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have tested these changes locally.
- [x] I have updated documentation if needed.
